### PR TITLE
Fixed find for Linux compatibility

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,1 +1,1 @@
-Copyright (c) 2020-2022 by Ivo Woltring
+Copyright (c) 2020-2023 by Ivo Woltring

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-    Copyright 2020 (c) Ivo Woltring
+    Copyright 2023 (c) Ivo Woltring
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ brew help
 
 # License
 
-    Copyright 2020 (c) Ivo Woltring
+    Copyright 2023 (c) Ivo Woltring
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/bin/mvn
+++ b/bin/mvn
@@ -38,7 +38,7 @@ if { [ -z "$MENV_DISABLE_WRAPPER" ] || [ "$MENV_DISABLE_WRAPPER" == false ]; } &
   MVN="$(pwd)/mvnw"
 else
   # Get the latest installed maven from HomeBrew's cellar
-  MVN="$(find "$(brew --cellar)"/maven -depth 1 -type d | sort | tail -1)/bin/mvn"
+  MVN="$(find "$(brew --cellar)"/maven -maxdepth 1 -type d | sort | tail -1)/bin/mvn"
 fi
 
 find_local_version_file "$MENV_DIR"


### PR DESCRIPTION
the -depth does not take arguments on Linux, so have to use -maxdepth 1 instead. Tested on Both Linux and MacOS, both still work.